### PR TITLE
Add FastAPI backend using PyTrends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # trendsscraper
+
+Minimal demo showing a Google Trends comparison backend and frontend.
+
+## Running
+
+```bash
+python run.py
+```
+
+This starts the FastAPI backend and opens a browser pointing at the demo
+frontend served from `frontend/index.html`.

--- a/backend/domain.py
+++ b/backend/domain.py
@@ -1,0 +1,111 @@
+import time
+from typing import List, Dict, Iterable, Tuple
+
+import numpy as np
+import pandas as pd
+from pytrends.request import TrendReq
+
+
+def _pytrends_client() -> TrendReq:
+    """Create a configured TrendReq client."""
+    return TrendReq(hl="en-US", tz=0, retries=2, backoff_factor=0.4,
+                    requests_args={"timeout": (10, 25)})
+
+
+def build_payload_and_fetch(keywords: List[str], timeframe: str, geo: str,
+                             category: int | None, gprop: str) -> pd.DataFrame:
+    """Fetch interest over time for given keywords."""
+    pt = _pytrends_client()
+    pt.build_payload(keywords, timeframe=timeframe, geo=geo, cat=category or 0,
+                     gprop=gprop)
+    df = pt.interest_over_time()
+    if 'isPartial' in df.columns:
+        df = df.drop(columns=['isPartial'])
+    return df
+
+
+def trimmed_median(values: Iterable[float], trim: float = 0.1) -> float:
+    """Return the trimmed median of the provided values."""
+    arr = np.array(list(values), dtype=float)
+    arr = arr[~np.isnan(arr)]
+    if arr.size == 0:
+        return float("nan")
+    arr.sort()
+    k = int(len(arr) * trim)
+    if k > 0:
+        arr = arr[k:-k]
+    return float(np.median(arr))
+
+
+def robust_slope(series: pd.Series) -> float:
+    """Compute a simple slope of the series using linear regression."""
+    if series.empty:
+        return 0.0
+    y = series.values
+    x = np.arange(len(y))
+    slope, _ = np.polyfit(x, y, 1)
+    return float(slope)
+
+
+def _scale_factor(anchor_base: pd.Series, anchor_pair: pd.Series) -> float | None:
+    """Compute scaling factor using anchor series."""
+    df = pd.concat([anchor_base, anchor_pair], axis=1, join='inner')
+    df = df.replace(0, np.nan).dropna()
+    if df.empty:
+        return None
+    ratios = df.iloc[:, 0] / df.iloc[:, 1]
+    return trimmed_median(ratios)
+
+
+def compare_trends(master: str, competitors: List[str], anchor: str,
+                    timeframe: str, geo: str, category: int | None,
+                    gprop: str) -> Tuple[List[str], pd.Series, List[Dict], List[str]]:
+    """
+    Perform baseline and pairwise queries then stitch via anchor.
+    Returns time buckets, master baseline series, competitor results and warnings.
+    """
+    baseline_df = build_payload_and_fetch([master, anchor], timeframe, geo, category, gprop)
+    m_base = baseline_df[master]
+    a_base = baseline_df[anchor]
+    time_buckets = baseline_df.index.strftime('%Y-%m-%d').tolist()
+
+    baseline_avg = float(m_base.mean())
+    competitor_results: List[Dict] = []
+    warnings: List[str] = []
+
+    for comp in competitors:
+        pair_df = build_payload_and_fetch([master, comp, anchor], timeframe, geo, category, gprop)
+        pair_df = pair_df.reindex(baseline_df.index)
+        a_pair = pair_df[anchor]
+        m_pair = pair_df[master]
+        c_pair = pair_df[comp]
+
+        scale = _scale_factor(a_base, a_pair)
+        if scale is None or np.isnan(scale):
+            warnings.append(f"Insufficient overlap for {comp}")
+            continue
+        m_adj = (m_pair * scale).reindex(baseline_df.index)
+        c_adj = (c_pair * scale).reindex(baseline_df.index)
+
+        raw_score = float(c_adj.mean())
+        rs = raw_score / baseline_avg if baseline_avg else 0.0
+        norm_score = rs * 100.0
+        slope = robust_slope(c_adj)
+        epsilon = max(baseline_avg * 0.01, 0.1)
+        if slope > epsilon:
+            trend = 'up'
+        elif slope < -epsilon:
+            trend = 'down'
+        else:
+            trend = 'stable'
+
+        competitor_results.append({
+            'name': comp,
+            'series': [float(v) for v in c_adj.values],
+            'relative_strength': rs,
+            'raw_score': raw_score,
+            'normalized_score': norm_score,
+            'trend': trend,
+        })
+
+    return time_buckets, m_base, competitor_results, warnings

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+
+from .domain import compare_trends
+from .models import CompareRequest, CompareResponse, CompetitorResult
+
+app = FastAPI(title="Trends Compare API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Serve the frontend as static files so that running this module launches the
+# complete application without extra setup.
+frontend_dir = Path(__file__).resolve().parent.parent / "frontend"
+if frontend_dir.exists():
+    app.mount("/", StaticFiles(directory=str(frontend_dir), html=True), name="frontend")
+
+
+@app.post("/api/trends/compare", response_model=CompareResponse)
+def trends_compare(req: CompareRequest) -> CompareResponse:
+    """Compare master against competitors using Google Trends."""
+    try:
+        time_buckets, master_baseline, competitors, warnings = compare_trends(
+            req.master,
+            req.competitors,
+            req.anchor,
+            req.timeframe,
+            req.geo,
+            req.category,
+            req.gprop,
+        )
+        return CompareResponse(
+            time_buckets=time_buckets,
+            master_baseline=[float(v) for v in master_baseline.values],
+            baseline_average=float(master_baseline.mean()),
+            competitors=[CompetitorResult(**c) for c in competitors],
+            warnings=warnings,
+        )
+    except Exception as exc:  # pragma: no cover - protective layer
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+if __name__ == "__main__":
+    import threading
+    import time
+    import webbrowser
+
+    import uvicorn
+
+    def open_browser():
+        time.sleep(1)
+        webbrowser.open("http://localhost:8000")
+
+    threading.Thread(target=open_browser, daemon=True).start()
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,32 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CompareRequest(BaseModel):
+    master: str
+    competitors: List[str]
+    anchor: str = Field(default="car insurance")
+    timeframe: str = Field(default="today 3-m")
+    geo: str = Field(default="IE")
+    category: Optional[int] = None
+    gprop: str = Field(default="")
+    repeat: int = Field(default=1, ge=1)
+    sleep_seconds: float = Field(default=1.0, ge=0)
+
+
+class CompetitorResult(BaseModel):
+    name: str
+    series: List[float]
+    relative_strength: float
+    raw_score: float
+    normalized_score: float
+    trend: str
+
+
+class CompareResponse(BaseModel):
+    time_buckets: List[str]
+    master_baseline: List[float]
+    baseline_average: float
+    competitors: List[CompetitorResult]
+    warnings: List[str] = []

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+pytrends
+pandas
+numpy
+pydantic

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,28 @@
+/*
+ * Minimal frontend module to request backend trends comparison.
+ */
+
+async function fetchTrendsCompare(payload) {
+  const res = await fetch('/api/trends/compare', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error('Backend request failed');
+  }
+  return res.json();
+}
+
+export async function runAnalysis(master, competitors, options = {}) {
+  const payload = {
+    master,
+    competitors,
+    anchor: options.anchor || 'car insurance',
+    timeframe: options.timeframe || 'today 3-m',
+    geo: options.geo || 'IE',
+    category: options.category || null,
+    gprop: options.gprop || '',
+  };
+  return fetchTrendsCompare(payload);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Trends Compare</title>
+</head>
+<body>
+  <h1>Trends Compare Demo</h1>
+  <button id="run">Run Analysis</button>
+  <pre id="output"></pre>
+  <script type="module">
+    import { runAnalysis } from './app.js';
+    document.getElementById('run').addEventListener('click', async () => {
+      try {
+        const res = await runAnalysis('Master', ['Competitor A', 'Competitor B']);
+        document.getElementById('output').textContent = JSON.stringify(res, null, 2);
+      } catch (err) {
+        document.getElementById('output').textContent = err.message;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/run.py
+++ b/run.py
@@ -1,0 +1,17 @@
+"""Entry point to start the Trends Compare app."""
+import threading
+import time
+import webbrowser
+
+import uvicorn
+from backend.main import app
+
+
+def open_browser():
+    time.sleep(1)
+    webbrowser.open("http://localhost:8000")
+
+
+if __name__ == "__main__":
+    threading.Thread(target=open_browser, daemon=True).start()
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from backend.domain import trimmed_median, robust_slope
+
+
+def test_trimmed_median():
+    series = pd.Series([1, 2, 3, 100])
+    assert trimmed_median(series, trim=0.25) == 2.5
+
+
+def test_robust_slope():
+    series = pd.Series([1, 2, 3, 4])
+    assert abs(robust_slope(series) - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- implement FastAPI service exposing `/api/trends/compare` using PyTrends
- add domain utilities for trimmed median scaling and trend metrics
- provide minimal frontend helper and unit tests
- serve the frontend directly from the FastAPI app and add `run.py` launcher so a single file starts backend and demo UI

## Testing
- `python -m pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_688f5e2c372c8328b2752112f1ae8c33